### PR TITLE
docs: fixed broken link: "How to Create an Open Source Program"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Organizations that have an OSPO or hires open source specialists to manage open 
 
 * [How to Create an Open Source Program](https://todogroup.org/resources/guides/how-to-create-an-open-source-program-office/)
 * [Measuring Your Open Source Program](https://todogroup.org/resources/guides/measuring-your-open-source-programs-success/)
-* [Tools for Managing Your Open Source Program](https://todogroup.org/guides/management-tools)
+* [Tools for Managing Your Open Source Program](https://todogroup.org/resources/guides/tools-for-managing-open-source-programs/)
 
 ## OSPO 101
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Organizations that have an OSPO or hires open source specialists to manage open 
 
 ## OSPO Guides
 
-* [How to Create an Open Source Program](https://todogroup.org/guides/create-program)
+* [How to Create an Open Source Program](https://todogroup.org/resources/guides/how-to-create-an-open-source-program-office/)
 * [Measuring Your Open Source Program](https://todogroup.org/guides/measuring)
 * [Tools for Managing Your Open Source Program](https://todogroup.org/guides/management-tools)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Organizations that have an OSPO or hires open source specialists to manage open 
 ## OSPO Guides
 
 * [How to Create an Open Source Program](https://todogroup.org/resources/guides/how-to-create-an-open-source-program-office/)
-* [Measuring Your Open Source Program](https://todogroup.org/guides/measuring)
+* [Measuring Your Open Source Program](https://todogroup.org/resources/guides/measuring-your-open-source-programs-success/)
 * [Tools for Managing Your Open Source Program](https://todogroup.org/guides/management-tools)
 
 ## OSPO 101


### PR DESCRIPTION
Fixed the link that was broken... it used to point out to: https://todogroup.org/guides/create-program

It now points to:
https://todogroup.org/resources/guides/how-to-create-an-open-source-program-office/